### PR TITLE
fix: fix horizontal scrolling bugs

### DIFF
--- a/src/editor/view.rs
+++ b/src/editor/view.rs
@@ -26,9 +26,6 @@ impl View {
     pub fn render(&mut self) -> Result<(), std::io::Error> {
         // TODO: separate implementation of render()
         // according to whether buffer is empty or not.
-
-        // FIXME: horizontally scrolling do not work!
-        // see: https://github.com/datahaikuninja/hecto/issues/1
         if !self.needs_redraw {
             return Ok(());
         }
@@ -37,13 +34,8 @@ impl View {
         for i in 0..height {
             if let Some(line) = self.buffer.lines.get(i + top) {
                 let left = self.scroll_offset.x;
-                let right = left + width;
-                let truncated_line = if line.len() >= width {
-                    &line[left..right]
-                } else {
-                    line
-                };
-                self.render_line(i, truncated_line)?;
+                let right = std::cmp::min(left + width, line.len());
+                self.render_line(i, line.get(left..right).unwrap_or_default())?;
             } else {
                 self.render_line(i, "~")?;
             }


### PR DESCRIPTION
closes #1 

水平方向のスクロールのバグを修正しました。

## 問題1: 現在カーソルがある行以外、水平方向にスクロールしない

正確には、「行の長さが端末表示幅を超える場合しかスクロールされない」だった。
行長に関係なく `scroll_offset` を基準にしたスライスを表示するようにすることで解消

## 問題2: スクロールし続けると panic する

端末右端が行末より後ろにかかると panic していた。
直接的な原因は range による範囲外参照だった。
表示範囲について範囲外にならないように行長との min をとることと、行が表示範囲の完全に外に出た場合空文字列で代替する (`unwrap_or_defaut()`) で対応

## 動作確認

- test.txt

```
abcdefghijklmnopqrstuvwxyz abcdefghijklmnopqrstuvwxyz abcdefghijklmnopqrstuvwxyz abcdefghijklmnopqrstuvwxyz abcdefghijklmnopqrstuvwxyz abcdefghijklmnopqrstuvwxyz
abcdefghijklmnopqrstuvwxyz abcdefghijklmnopqrstuvwxyz abcdefghijklmnopqrstuvwxyz
abcdefghijklmnopqrstuvwxyz abcdefghijklmnopqrstuvwxyz
abcdefghijklmnopqrstuvwxyz
```


https://github.com/user-attachments/assets/7b63571b-6fd1-4cfc-904f-60aa72061428

