### PR TITLE
fix: remove unnecessary empty line below last line of buffer

### DIFF
--- a/src/editor/view/buffer.rs
+++ b/src/editor/view/buffer.rs
@@ -8,7 +8,7 @@ impl Buffer {
         self.lines.is_empty()
     }
     pub fn load(&mut self, contents: &str) {
-        let lines: Vec<_> = contents.split("\n").map(|s| String::from(s)).collect();
+        let lines: Vec<_> = contents.lines().map(|s| String::from(s)).collect();
         self.lines = lines;
     }
 }


### PR DESCRIPTION
closes #3 

`split("\n")` で行分割すると、最後の改行文字の後ろに空文字列がつくられてしまうので、代わりに `lines()` で行分割するようにする

[Playground link](https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=24dd1593be0e6ca1ac5449228bfd85e4)

- main

<img width="1470" alt="Screenshot 2024-07-15 11 24 09" src="https://github.com/user-attachments/assets/72075697-5f91-4e22-8f09-be10b0be0b9b">

- fix#02

<img width="1470" alt="Screenshot 2024-07-15 11 15 08" src="https://github.com/user-attachments/assets/e3920991-5f4f-49fa-a4a8-eaa3d434152b">
