### PR TITLE
feat: support unicode segmentation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,6 +50,7 @@ name = "hecto"
 version = "0.1.0"
 dependencies = [
  "crossterm",
+ "unicode-segmentation",
 ]
 
 [[package]]
@@ -159,6 +160,12 @@ name = "smallvec"
 version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202"
 
 [[package]]
 name = "wasi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -51,6 +51,7 @@ version = "0.1.0"
 dependencies = [
  "crossterm",
  "unicode-segmentation",
+ "unicode-width",
 ]
 
 [[package]]
@@ -166,6 +167,12 @@ name = "unicode-segmentation"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0336d538f7abc86d282a4189614dfaa90810dfc2c6f6427eaf88e16311dd225d"
 
 [[package]]
 name = "wasi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,3 +5,4 @@ edition = "2021"
 
 [dependencies]
 crossterm = "0.27.0"
+unicode-segmentation = "*"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,4 @@ edition = "2021"
 [dependencies]
 crossterm = "0.27.0"
 unicode-segmentation = "*"
+unicode-width = "*"

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -73,7 +73,7 @@ impl Editor {
             print!("Goodbye!\r\n");
         } else {
             self.view.render()?;
-            let pos = self.view.get_position();
+            let pos = self.view.get_relative_position();
             Terminal::move_cursor_to(pos)?;
         }
         Ok(())

--- a/src/editor/terminal.rs
+++ b/src/editor/terminal.rs
@@ -13,7 +13,7 @@ pub struct Size {
     pub width: usize,
 }
 
-#[derive(Copy, Clone, Default)]
+#[derive(Copy, Clone, Default, Debug)]
 pub struct Position {
     pub col: usize,
     pub row: usize,

--- a/src/editor/view.rs
+++ b/src/editor/view.rs
@@ -78,9 +78,15 @@ impl View {
         Ok(())
     }
     pub fn get_position(&self) -> Position {
+        let Location { x, y: ypos } = self.location;
+        let xpos = self
+            .buffer
+            .lines
+            .get(ypos)
+            .map_or(0, |line| line.calc_width_until_grapheme_index(x));
         Position {
-            row: self.location.y - self.scroll_offset.y,
-            col: self.location.x - self.scroll_offset.x,
+            row: ypos - self.scroll_offset.y,
+            col: xpos - self.scroll_offset.x,
         }
     }
     fn render_line(&self, row: usize, text: &str) -> Result<(), std::io::Error> {

--- a/src/editor/view.rs
+++ b/src/editor/view.rs
@@ -14,7 +14,7 @@ pub struct View {
     buffer: Buffer,
     needs_redraw: bool,
     location: Location,
-    scroll_offset: Location,
+    scroll_offset: Position,
 }
 
 impl View {
@@ -31,13 +31,13 @@ impl View {
         if !self.needs_redraw {
             return Ok(());
         }
-        let top = self.scroll_offset.y;
+        let top = self.scroll_offset.row;
         let Size { height, width } = Terminal::size()?;
         for i in 0..height {
             if let Some(line) = self.buffer.lines.get(i + top) {
-                let left = self.scroll_offset.x;
+                let left = self.scroll_offset.col;
                 let right = left + width;
-                let display_line = line.get_range(left, right);
+                let display_line = line.get_visible_graphemes(left, right);
                 self.render_line(i, &display_line)?;
             } else {
                 self.render_line(i, "~")?;
@@ -77,7 +77,14 @@ impl View {
         self.update_scroll_offset()?;
         Ok(())
     }
-    pub fn get_position(&self) -> Position {
+    pub fn get_relative_position(&self) -> Position {
+        let Position { row, col } = self.get_absolute_position();
+        Position {
+            col: col - self.scroll_offset.col,
+            row: row - self.scroll_offset.row,
+        }
+    }
+    pub fn get_absolute_position(&self) -> Position {
         let Location { x, y: ypos } = self.location;
         let xpos = self
             .buffer
@@ -85,8 +92,8 @@ impl View {
             .get(ypos)
             .map_or(0, |line| line.calc_width_until_grapheme_index(x));
         Position {
-            row: ypos - self.scroll_offset.y,
-            col: xpos - self.scroll_offset.x,
+            row: ypos,
+            col: xpos,
         }
     }
     fn render_line(&self, row: usize, text: &str) -> Result<(), std::io::Error> {
@@ -97,28 +104,28 @@ impl View {
         Ok(())
     }
     fn update_scroll_offset(&mut self) -> Result<(), std::io::Error> {
-        let Location { x, y } = self.location;
         let Size { width, height } = Terminal::size()?;
         let mut offset_changed = false;
+        let next_pos = self.get_absolute_position();
 
         // Scroll vertically
-        if y < self.scroll_offset.y {
-            self.scroll_offset.y = y;
+        if next_pos.row < self.scroll_offset.row {
+            self.scroll_offset.row = next_pos.row;
             offset_changed = true;
-        } else if y >= self.scroll_offset.y.saturating_add(height) {
-            self.scroll_offset.y = y.saturating_sub(height).saturating_add(1);
+        } else if next_pos.row >= self.scroll_offset.row.saturating_add(height) {
+            self.scroll_offset.row = next_pos.row.saturating_sub(height).saturating_add(1);
             offset_changed = true;
         }
 
         //Scroll horizontally
-        if x < self.scroll_offset.x {
-            self.scroll_offset.x = x;
+        if next_pos.col < self.scroll_offset.col {
+            self.scroll_offset.col = next_pos.col;
             offset_changed = true;
-        } else if x >= self.scroll_offset.x.saturating_add(width) {
-            self.scroll_offset.x = x.saturating_sub(width).saturating_add(1);
+        } else if next_pos.col >= self.scroll_offset.col.saturating_add(width) {
+            self.scroll_offset.col = next_pos.col.saturating_sub(width).saturating_add(1);
             offset_changed = true;
         }
-        self.needs_redraw = offset_changed;
+        self.needs_redraw = self.needs_redraw || offset_changed;
         Ok(())
     }
     fn draw_welcom_message() -> Result<(), std::io::Error> {
@@ -142,7 +149,7 @@ impl Default for View {
             buffer: Buffer::default(),
             needs_redraw: true,
             location: Location::default(),
-            scroll_offset: Location::default(),
+            scroll_offset: Position::default(),
         }
     }
 }

--- a/src/editor/view/buffer.rs
+++ b/src/editor/view/buffer.rs
@@ -1,6 +1,8 @@
+use super::line::Line;
+
 #[derive(Default)]
 pub struct Buffer {
-    pub lines: Vec<String>,
+    pub lines: Vec<Line>,
 }
 
 impl Buffer {
@@ -8,7 +10,7 @@ impl Buffer {
         self.lines.is_empty()
     }
     pub fn load(&mut self, contents: &str) {
-        let lines: Vec<_> = contents.lines().map(String::from).collect();
+        let lines: Vec<_> = contents.lines().map(Line::from_str).collect();
         self.lines = lines;
     }
 }

--- a/src/editor/view/line.rs
+++ b/src/editor/view/line.rs
@@ -1,0 +1,26 @@
+use unicode_segmentation::UnicodeSegmentation;
+
+pub struct Line {
+    content: String,
+}
+
+impl Line {
+    pub fn from_str(s: &str) -> Self {
+        Self {
+            content: String::from(s),
+        }
+    }
+    pub fn get_range(&self, left: usize, right: usize) -> String {
+        let end = std::cmp::min(right, self.len());
+        let display_line = self
+            .content
+            .graphemes(true)
+            .skip(left)
+            .take(end.saturating_sub(left))
+            .collect::<String>();
+        display_line
+    }
+    pub fn len(&self) -> usize {
+        self.content.graphemes(true).count()
+    }
+}

--- a/src/editor/view/line.rs
+++ b/src/editor/view/line.rs
@@ -14,6 +14,12 @@ impl GraphemeWidth {
             _ => panic!("Invalid grapheme width"),
         }
     }
+    pub fn to_usize(&self) -> usize {
+        match self {
+            Self::Half => 1,
+            Self::Full => 2,
+        }
+    }
 }
 
 struct Grapheme {
@@ -46,6 +52,13 @@ impl Line {
             .map(|g| g.string.clone())
             .collect::<String>();
         display_line
+    }
+    pub fn calc_width_until_grapheme_index(&self, graphme_index: usize) -> usize {
+        self.graphemes
+            .iter()
+            .take(graphme_index)
+            .map(|g| g.width.to_usize())
+            .sum()
     }
     pub fn len(&self) -> usize {
         self.graphemes.len()

--- a/src/editor/view/line.rs
+++ b/src/editor/view/line.rs
@@ -1,26 +1,53 @@
 use unicode_segmentation::UnicodeSegmentation;
+use unicode_width::UnicodeWidthStr;
+
+enum GraphemeWidth {
+    Half,
+    Full,
+}
+
+impl GraphemeWidth {
+    pub fn from_usize(w: usize) -> Self {
+        match w {
+            0 | 1 => Self::Half,
+            2 => Self::Full,
+            _ => panic!("Invalid grapheme width"),
+        }
+    }
+}
+
+struct Grapheme {
+    string: String,
+    width: GraphemeWidth,
+}
 
 pub struct Line {
-    content: String,
+    graphemes: Vec<Grapheme>,
 }
 
 impl Line {
     pub fn from_str(s: &str) -> Self {
-        Self {
-            content: String::from(s),
-        }
+        let graphemes = s
+            .graphemes(true)
+            .map(|s| Grapheme {
+                string: String::from(s),
+                width: GraphemeWidth::from_usize(s.width_cjk()),
+            })
+            .collect::<Vec<_>>();
+        Self { graphemes }
     }
     pub fn get_range(&self, left: usize, right: usize) -> String {
         let end = std::cmp::min(right, self.len());
         let display_line = self
-            .content
-            .graphemes(true)
+            .graphemes
+            .iter()
             .skip(left)
             .take(end.saturating_sub(left))
+            .map(|g| g.string.clone())
             .collect::<String>();
         display_line
     }
     pub fn len(&self) -> usize {
-        self.content.graphemes(true).count()
+        self.graphemes.len()
     }
 }

--- a/src/editor/view/line.rs
+++ b/src/editor/view/line.rs
@@ -42,16 +42,29 @@ impl Line {
             .collect::<Vec<_>>();
         Self { graphemes }
     }
-    pub fn get_range(&self, left: usize, right: usize) -> String {
-        let end = std::cmp::min(right, self.len());
-        let display_line = self
-            .graphemes
-            .iter()
-            .skip(left)
-            .take(end.saturating_sub(left))
-            .map(|g| g.string.clone())
-            .collect::<String>();
-        display_line
+    pub fn get_visible_graphemes(&self, left: usize, right: usize) -> String {
+        let mut result = String::new();
+        let mut current_pos = 0;
+        for grapheme in &self.graphemes {
+            let next_pos = current_pos + grapheme.width.to_usize();
+            if current_pos >= right {
+                break;
+            }
+            if next_pos > left {
+                // Replace cut-off text with '>' or '<'.
+                if next_pos > right {
+                    result.push('>');
+                } else if current_pos < left {
+                    result.push('<');
+                }
+                // add fully visible grapheme
+                else {
+                    result.push_str(&grapheme.string);
+                }
+            }
+            current_pos = next_pos;
+        }
+        result
     }
     pub fn calc_width_until_grapheme_index(&self, graphme_index: usize) -> usize {
         self.graphemes


### PR DESCRIPTION
- [x] テキストの Grapheme による区切り位置を管理する
- [x] テキストの表示幅を文字種によって適切に切り替える
- [x] (横方向の) カーソル表示位置の移動をテキスト幅単位で行われるように制御する
- [ ] 縦方向のカーソル移動でカーソル位置の横ずれを抑制
- [x] スクロールした際に、表示される文字の範囲を文字幅を考慮して適切に設定する