### PR TITLE
Implement insert mode

### DIFF
--- a/src/editor.rs
+++ b/src/editor.rs
@@ -90,6 +90,9 @@ impl Editor {
             InsertModeCommand::Backspace => {
                 self.view.handle_backspace();
             }
+            InsertModeCommand::InsertNewLine => {
+                self.view.insert_newline();
+            }
             InsertModeCommand::Nop => (),
         }
         Ok(())

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -80,6 +80,9 @@ impl Editor {
             InsertModeCommand::LeaveInsertMode => {
                 self.mode = EditorMode::NormalMode;
             }
+            InsertModeCommand::Insert(c) => {
+                self.view.insert_char(c);
+            }
             InsertModeCommand::Nop => (),
         }
         Ok(())

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -86,13 +86,13 @@ impl Editor {
                 self.view.normalize_cursor_position(false)?;
             }
             InsertModeCommand::Insert(c) => {
-                self.view.insert_char(c);
+                self.view.insert_char(c)?;
             }
             InsertModeCommand::Backspace => {
-                self.view.handle_backspace();
+                self.view.handle_backspace()?;
             }
             InsertModeCommand::InsertNewLine => {
-                self.view.insert_newline();
+                self.view.insert_newline()?;
             }
             InsertModeCommand::Nop => (),
         }

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -1,8 +1,7 @@
-use crossterm::event::{
-    read,
-    Event::{self, Key},
-    KeyCode, KeyEvent, KeyEventKind, KeyModifiers,
-};
+use crossterm::event::{read, Event};
+
+mod editor_command;
+use editor_command::Command;
 
 mod terminal;
 use terminal::Terminal;
@@ -51,25 +50,15 @@ impl Editor {
         Ok(())
     }
     fn evaluate_evnet(&mut self, event: &Event) -> Result<(), std::io::Error> {
-        if let Key(KeyEvent {
-            code,
-            modifiers,
-            kind: KeyEventKind::Press,
-            ..
-        }) = event
-        {
-            match code {
-                KeyCode::Char('q') if *modifiers == KeyModifiers::CONTROL => {
-                    self.should_quit = true;
-                }
-                KeyCode::Char('h')
-                | KeyCode::Char('j')
-                | KeyCode::Char('k')
-                | KeyCode::Char('l') => {
-                    self.view.handle_move(*code)?;
-                }
-                _ => (),
+        let command = Command::from_key_event(event);
+        match command {
+            Command::Quit => {
+                self.should_quit = true;
             }
+            Command::CursorMove(direction) => {
+                self.view.handle_move(direction)?;
+            }
+            Command::Nop => (),
         }
         Ok(())
     }

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -83,6 +83,7 @@ impl Editor {
         match command {
             InsertModeCommand::LeaveInsertMode => {
                 self.mode = EditorMode::NormalMode;
+                self.view.normalize_cursor_position(false)?;
             }
             InsertModeCommand::Insert(c) => {
                 self.view.insert_char(c);

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -1,7 +1,7 @@
 use crossterm::event::{read, Event};
 
 mod editor_command;
-use editor_command::{EditorMode, InsertModeCommand, NormalModeCommand};
+use editor_command::{Direction, EditorMode, InsertModeCommand, NormalModeCommand};
 
 mod terminal;
 use terminal::Terminal;
@@ -65,9 +65,13 @@ impl Editor {
                 self.should_quit = true;
             }
             NormalModeCommand::CursorMove(direction) => {
-                self.view.handle_move(direction)?;
+                self.view.handle_move(direction, false)?;
             }
             NormalModeCommand::EnterInsertMode => {
+                self.mode = EditorMode::InsertMode;
+            }
+            NormalModeCommand::EnterInsertModeAppend => {
+                self.view.handle_move(Direction::Right, true)?;
                 self.mode = EditorMode::InsertMode;
             }
             NormalModeCommand::Nop => (),

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -87,6 +87,9 @@ impl Editor {
             InsertModeCommand::Insert(c) => {
                 self.view.insert_char(c);
             }
+            InsertModeCommand::Backspace => {
+                self.view.handle_backspace();
+            }
             InsertModeCommand::Nop => (),
         }
         Ok(())

--- a/src/editor/editor_command.rs
+++ b/src/editor/editor_command.rs
@@ -22,6 +22,7 @@ pub enum Direction {
 pub enum NormalModeCommand {
     CursorMove(Direction),
     EnterInsertMode,
+    EnterInsertModeAppend,
     Quit,
     Nop,
 }
@@ -42,6 +43,7 @@ impl NormalModeCommand {
                 KeyCode::Char('k') => Self::CursorMove(Direction::Up),
                 KeyCode::Char('l') => Self::CursorMove(Direction::Right),
                 KeyCode::Char('i') => Self::EnterInsertMode,
+                KeyCode::Char('a') => Self::EnterInsertModeAppend,
                 _ => Self::Nop,
             };
             command

--- a/src/editor/editor_command.rs
+++ b/src/editor/editor_command.rs
@@ -1,6 +1,17 @@
 use crossterm::event::Event::{self, Key};
 use crossterm::event::{KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
 
+pub enum EditorMode {
+    NormalMode,
+    InsertMode,
+}
+
+impl Default for EditorMode {
+    fn default() -> Self {
+        Self::NormalMode
+    }
+}
+
 pub enum Direction {
     Left,
     Right,
@@ -8,13 +19,14 @@ pub enum Direction {
     Down,
 }
 
-pub enum Command {
+pub enum NormalModeCommand {
     CursorMove(Direction),
+    EnterInsertMode,
     Quit,
     Nop,
 }
 
-impl Command {
+impl NormalModeCommand {
     pub fn from_key_event(event: &Event) -> Self {
         if let Key(KeyEvent {
             code,
@@ -29,6 +41,31 @@ impl Command {
                 KeyCode::Char('j') => Self::CursorMove(Direction::Down),
                 KeyCode::Char('k') => Self::CursorMove(Direction::Up),
                 KeyCode::Char('l') => Self::CursorMove(Direction::Right),
+                KeyCode::Char('i') => Self::EnterInsertMode,
+                _ => Self::Nop,
+            };
+            command
+        } else {
+            Self::Nop
+        }
+    }
+}
+
+pub enum InsertModeCommand {
+    LeaveInsertMode,
+    Nop,
+}
+
+impl InsertModeCommand {
+    pub fn from_key_event(event: &Event) -> Self {
+        if let Key(KeyEvent {
+            code,
+            kind: KeyEventKind::Press,
+            ..
+        }) = event
+        {
+            let command = match code {
+                KeyCode::Esc => Self::LeaveInsertMode,
                 _ => Self::Nop,
             };
             command

--- a/src/editor/editor_command.rs
+++ b/src/editor/editor_command.rs
@@ -56,6 +56,7 @@ impl NormalModeCommand {
 pub enum InsertModeCommand {
     LeaveInsertMode,
     Insert(char),
+    Backspace,
     Nop,
 }
 
@@ -70,6 +71,7 @@ impl InsertModeCommand {
         {
             let command = match code {
                 KeyCode::Char(c) if *modifiers == KeyModifiers::NONE => Self::Insert(*c),
+                KeyCode::Backspace if *modifiers == KeyModifiers::NONE => Self::Backspace,
                 KeyCode::Esc => Self::LeaveInsertMode,
                 _ => Self::Nop,
             };

--- a/src/editor/editor_command.rs
+++ b/src/editor/editor_command.rs
@@ -1,0 +1,39 @@
+use crossterm::event::Event::{self, Key};
+use crossterm::event::{KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
+
+pub enum Direction {
+    Left,
+    Right,
+    Up,
+    Down,
+}
+
+pub enum Command {
+    CursorMove(Direction),
+    Quit,
+    Nop,
+}
+
+impl Command {
+    pub fn from_key_event(event: &Event) -> Self {
+        if let Key(KeyEvent {
+            code,
+            modifiers,
+            kind: KeyEventKind::Press,
+            ..
+        }) = event
+        {
+            let command = match code {
+                KeyCode::Char('q') if *modifiers == KeyModifiers::CONTROL => Self::Quit,
+                KeyCode::Char('h') => Self::CursorMove(Direction::Left),
+                KeyCode::Char('j') => Self::CursorMove(Direction::Down),
+                KeyCode::Char('k') => Self::CursorMove(Direction::Up),
+                KeyCode::Char('l') => Self::CursorMove(Direction::Right),
+                _ => Self::Nop,
+            };
+            command
+        } else {
+            Self::Nop
+        }
+    }
+}

--- a/src/editor/editor_command.rs
+++ b/src/editor/editor_command.rs
@@ -53,6 +53,7 @@ impl NormalModeCommand {
 
 pub enum InsertModeCommand {
     LeaveInsertMode,
+    Insert(char),
     Nop,
 }
 
@@ -60,11 +61,13 @@ impl InsertModeCommand {
     pub fn from_key_event(event: &Event) -> Self {
         if let Key(KeyEvent {
             code,
+            modifiers,
             kind: KeyEventKind::Press,
             ..
         }) = event
         {
             let command = match code {
+                KeyCode::Char(c) if *modifiers == KeyModifiers::NONE => Self::Insert(*c),
                 KeyCode::Esc => Self::LeaveInsertMode,
                 _ => Self::Nop,
             };

--- a/src/editor/editor_command.rs
+++ b/src/editor/editor_command.rs
@@ -57,6 +57,7 @@ pub enum InsertModeCommand {
     LeaveInsertMode,
     Insert(char),
     Backspace,
+    InsertNewLine,
     Nop,
 }
 
@@ -71,7 +72,9 @@ impl InsertModeCommand {
         {
             let command = match code {
                 KeyCode::Char(c) if *modifiers == KeyModifiers::NONE => Self::Insert(*c),
+                KeyCode::Tab if *modifiers == KeyModifiers::NONE => Self::Insert('\t'),
                 KeyCode::Backspace if *modifiers == KeyModifiers::NONE => Self::Backspace,
+                KeyCode::Enter if *modifiers == KeyModifiers::NONE => Self::InsertNewLine,
                 KeyCode::Esc => Self::LeaveInsertMode,
                 _ => Self::Nop,
             };

--- a/src/editor/view.rs
+++ b/src/editor/view.rs
@@ -81,9 +81,20 @@ impl View {
             }
         }
 
+        self.location = Location { x, y };
+        self.normalize_cursor_position(allow_past_end)?;
+        self.update_scroll_offset()?;
+        Ok(())
+    }
+    pub fn normalize_cursor_position(
+        &mut self,
+        allow_past_end: bool,
+    ) -> Result<(), std::io::Error> {
         // Ensure self.location points to valid text position.
+        let Location { mut x, mut y } = self.location;
         let n_line = self.buffer.lines.len();
         y = std::cmp::min(y, n_line.saturating_sub(1));
+
         let line_length = self.buffer.lines.get(y).map_or(0, |s| s.len());
         let idx_lim = if allow_past_end {
             line_length

--- a/src/editor/view.rs
+++ b/src/editor/view.rs
@@ -113,6 +113,28 @@ impl View {
         }
         self.needs_redraw = true;
     }
+    pub fn handle_backspace(&mut self) {
+        if self.location.x > 0 {
+            self.location.x -= 1;
+            self.buffer.delete_grapheme(self.location);
+            self.needs_redraw = true;
+        } else if self.location.x == 0 {
+            if self.location.y == 0 {
+                return;
+            }
+            let orig_len = self
+                .buffer
+                .lines
+                .get(self.location.y)
+                .map_or(0, |line| line.len());
+            self.buffer.join_adjacent_rows(self.location.y - 1);
+            self.location = Location {
+                x: orig_len,
+                y: self.location.y - 1,
+            };
+            self.needs_redraw = true;
+        }
+    }
     pub fn get_relative_position(&self) -> Position {
         let Position { row, col } = self.get_absolute_position();
         Position {

--- a/src/editor/view.rs
+++ b/src/editor/view.rs
@@ -87,6 +87,23 @@ impl View {
         self.update_scroll_offset()?;
         Ok(())
     }
+    pub fn insert_char(&mut self, c: char) {
+        let orig_len = self
+            .buffer
+            .lines
+            .get(self.location.y)
+            .map_or(0, |line| line.len());
+        self.buffer.insert_char(c, self.location);
+        let new_len = self
+            .buffer
+            .lines
+            .get(self.location.y)
+            .map_or(0, |line| line.len());
+        if new_len > orig_len {
+            self.location.x += 1;
+        }
+        self.needs_redraw = true;
+    }
     pub fn get_relative_position(&self) -> Position {
         let Position { row, col } = self.get_absolute_position();
         Position {

--- a/src/editor/view.rs
+++ b/src/editor/view.rs
@@ -135,6 +135,14 @@ impl View {
             self.needs_redraw = true;
         }
     }
+    pub fn insert_newline(&mut self) {
+        self.buffer.insert_newline(self.location);
+        self.location = Location {
+            x: 0,
+            y: self.location.y + 1,
+        };
+        self.needs_redraw = true;
+    }
     pub fn get_relative_position(&self) -> Position {
         let Position { row, col } = self.get_absolute_position();
         Position {

--- a/src/editor/view.rs
+++ b/src/editor/view.rs
@@ -1,6 +1,6 @@
 use super::terminal::{Position, Size, Terminal};
 
-use crossterm::event::KeyCode;
+use super::editor_command::Direction;
 
 mod line;
 use line::Grapheme;
@@ -60,22 +60,21 @@ impl View {
         self.needs_redraw = false;
         Ok(())
     }
-    pub fn handle_move(&mut self, key_code: KeyCode) -> Result<(), std::io::Error> {
+    pub fn handle_move(&mut self, direction: Direction) -> Result<(), std::io::Error> {
         let Location { mut x, mut y } = self.location;
-        match key_code {
-            KeyCode::Char('h') => {
+        match direction {
+            Direction::Left => {
                 x = x.saturating_sub(1);
             }
-            KeyCode::Char('j') => {
+            Direction::Down => {
                 y = y.saturating_add(1);
             }
-            KeyCode::Char('k') => {
+            Direction::Up => {
                 y = y.saturating_sub(1);
             }
-            KeyCode::Char('l') => {
+            Direction::Right => {
                 x = x.saturating_add(1);
             }
-            _ => (),
         }
 
         // Ensure self.location points to valid text position.

--- a/src/editor/view.rs
+++ b/src/editor/view.rs
@@ -60,7 +60,11 @@ impl View {
         self.needs_redraw = false;
         Ok(())
     }
-    pub fn handle_move(&mut self, direction: Direction) -> Result<(), std::io::Error> {
+    pub fn handle_move(
+        &mut self,
+        direction: Direction,
+        allow_past_end: bool,
+    ) -> Result<(), std::io::Error> {
         let Location { mut x, mut y } = self.location;
         match direction {
             Direction::Left => {
@@ -81,7 +85,12 @@ impl View {
         let n_line = self.buffer.lines.len();
         y = std::cmp::min(y, n_line.saturating_sub(1));
         let line_length = self.buffer.lines.get(y).map_or(0, |s| s.len());
-        x = std::cmp::min(x, line_length.saturating_sub(1));
+        let idx_lim = if allow_past_end {
+            line_length
+        } else {
+            line_length.saturating_sub(1)
+        };
+        x = std::cmp::min(x, idx_lim);
 
         self.location = Location { x, y };
         self.update_scroll_offset()?;

--- a/src/editor/view.rs
+++ b/src/editor/view.rs
@@ -108,17 +108,9 @@ impl View {
         Ok(())
     }
     pub fn insert_char(&mut self, c: char) {
-        let orig_len = self
-            .buffer
-            .lines
-            .get(self.location.y)
-            .map_or(0, |line| line.len());
+        let orig_len = self.buffer.get_line_length(self.location.y);
         self.buffer.insert_char(c, self.location);
-        let new_len = self
-            .buffer
-            .lines
-            .get(self.location.y)
-            .map_or(0, |line| line.len());
+        let new_len = self.buffer.get_line_length(self.location.y);
         if new_len > orig_len {
             self.location.x += 1;
         }
@@ -133,11 +125,7 @@ impl View {
             if self.location.y == 0 {
                 return;
             }
-            let orig_len = self
-                .buffer
-                .lines
-                .get(self.location.y)
-                .map_or(0, |line| line.len());
+            let orig_len = self.buffer.get_line_length(self.location.y - 1);
             self.buffer.join_adjacent_rows(self.location.y - 1);
             self.location = Location {
                 x: orig_len,

--- a/src/editor/view/buffer.rs
+++ b/src/editor/view/buffer.rs
@@ -14,6 +14,9 @@ impl Buffer {
         let lines: Vec<_> = contents.lines().map(Line::from_str).collect();
         self.lines = lines;
     }
+    pub fn get_line_length(&self, line_index: usize) -> usize {
+        self.lines.get(line_index).map_or(0, |line| line.len())
+    }
     pub fn insert_char(&mut self, c: char, loc: Location) {
         if loc.y >= self.lines.len() {
             // TODO: insert new line at the end of buffer

--- a/src/editor/view/buffer.rs
+++ b/src/editor/view/buffer.rs
@@ -29,4 +29,8 @@ impl Buffer {
         let current_line = &mut self.lines[idx];
         current_line.push_line(&next_line);
     }
+    pub fn insert_newline(&mut self, loc: Location) {
+        let remainder = self.lines[loc.y].split_off(loc.x);
+        self.lines.insert(loc.y + 1, remainder);
+    }
 }

--- a/src/editor/view/buffer.rs
+++ b/src/editor/view/buffer.rs
@@ -21,4 +21,12 @@ impl Buffer {
         }
         self.lines[loc.y].insert_char(c, loc.x);
     }
+    pub fn delete_grapheme(&mut self, loc: Location) {
+        self.lines[loc.y].delete_grapheme(loc.x);
+    }
+    pub fn join_adjacent_rows(&mut self, idx: usize) {
+        let next_line = self.lines.remove(idx + 1);
+        let current_line = &mut self.lines[idx];
+        current_line.push_line(&next_line);
+    }
 }

--- a/src/editor/view/buffer.rs
+++ b/src/editor/view/buffer.rs
@@ -1,4 +1,5 @@
 use super::line::Line;
+use super::Location;
 
 #[derive(Default)]
 pub struct Buffer {
@@ -12,5 +13,12 @@ impl Buffer {
     pub fn load(&mut self, contents: &str) {
         let lines: Vec<_> = contents.lines().map(Line::from_str).collect();
         self.lines = lines;
+    }
+    pub fn insert_char(&mut self, c: char, loc: Location) {
+        if loc.y >= self.lines.len() {
+            // TODO: insert new line at the end of buffer
+            return;
+        }
+        self.lines[loc.y].insert_char(c, loc.x);
     }
 }

--- a/src/editor/view/line.rs
+++ b/src/editor/view/line.rs
@@ -1,3 +1,5 @@
+use core::fmt;
+
 use unicode_segmentation::UnicodeSegmentation;
 use unicode_width::UnicodeWidthStr;
 
@@ -120,5 +122,27 @@ impl Line {
             result.push(c);
         }
         self.graphemes = str_to_graphemes(&result);
+    }
+    pub fn delete_grapheme(&mut self, idx: usize) {
+        let mut result = String::new();
+
+        for (i, grapheme) in self.graphemes.iter().enumerate() {
+            if i != idx {
+                result.push_str(&grapheme.string);
+            }
+        }
+        self.graphemes = str_to_graphemes(&result);
+    }
+    pub fn push_line(&mut self, other: &Self) {
+        let mut result = self.to_string();
+        result.push_str(&other.to_string());
+        self.graphemes = str_to_graphemes(&result);
+    }
+}
+
+impl fmt::Display for Line {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        let result: String = self.graphemes.iter().map(|g| g.string.clone()).collect();
+        write!(formatter, "{result}")
     }
 }

--- a/src/editor/view/line.rs
+++ b/src/editor/view/line.rs
@@ -51,19 +51,24 @@ impl Grapheme {
     }
 }
 
+fn str_to_graphemes(s: &str) -> Vec<Grapheme> {
+    let graphemes = s
+        .graphemes(true)
+        .map(|s| Grapheme {
+            string: String::from(s),
+            width: GraphemeWidth::from_usize(s.width_cjk()),
+        })
+        .collect::<Vec<_>>();
+    graphemes
+}
+
 pub struct Line {
     graphemes: Vec<Grapheme>,
 }
 
 impl Line {
     pub fn from_str(s: &str) -> Self {
-        let graphemes = s
-            .graphemes(true)
-            .map(|s| Grapheme {
-                string: String::from(s),
-                width: GraphemeWidth::from_usize(s.width_cjk()),
-            })
-            .collect::<Vec<_>>();
+        let graphemes = str_to_graphemes(s);
         Self { graphemes }
     }
     pub fn get_nth_grapheme(&self, index: usize) -> Option<Grapheme> {
@@ -102,5 +107,18 @@ impl Line {
     }
     pub fn len(&self) -> usize {
         self.graphemes.len()
+    }
+    pub fn insert_char(&mut self, c: char, idx: usize) {
+        let mut result = String::new();
+        for (i, grapheme) in self.graphemes.iter().enumerate() {
+            if i == idx {
+                result.push(c);
+            }
+            result.push_str(&grapheme.string);
+        }
+        if idx >= self.len() {
+            result.push(c);
+        }
+        self.graphemes = str_to_graphemes(&result);
     }
 }

--- a/src/editor/view/line.rs
+++ b/src/editor/view/line.rs
@@ -138,6 +138,12 @@ impl Line {
         result.push_str(&other.to_string());
         self.graphemes = str_to_graphemes(&result);
     }
+    pub fn split_off(&mut self, at: usize) -> Self {
+        let remainder = self.graphemes.split_off(at);
+        Self {
+            graphemes: remainder,
+        }
+    }
 }
 
 impl fmt::Display for Line {


### PR DESCRIPTION
closes #15 

- [x] Insert mode に入る / Insert mode を抜ける
  - [x] EnterInsertMode (`i`)
  - [x] EnterInsertMode (append) (`a`) 
  - [x] LeaveInsertMode (`Esc`)
- [x] 通常の (printable な) UTF-8 文字の挿入
- [x] `Backspace` による文字の削除
- [x] `Enter` による改行
- [x] スクロールの更新