### PR TITLE
Restore terminal state when panicking

### DIFF
--- a/src/editor.rs
+++ b/src/editor.rs
@@ -10,22 +10,23 @@ use terminal::Terminal;
 mod view;
 use view::View;
 
-#[derive(Default)]
 pub struct Editor {
     should_quit: bool,
     view: View,
 }
 
 impl Editor {
-    pub fn new(filename: &str) -> Self {
-        // TODO: consider execute read_to_string inside Buffer::load().
-        let contents = std::fs::read_to_string(filename).expect("cannot open file");
-        let mut view = View::default();
-        view.load(&contents);
+    pub fn new() -> Self {
+        let view = View::default();
         Self {
             should_quit: false,
             view,
         }
+    }
+    pub fn load_file(&mut self, filename: &str) {
+        // TODO: consider execute read_to_string inside Buffer::load().
+        let contents = std::fs::read_to_string(filename).expect("cannot open file");
+        self.view.load(&contents);
     }
     pub fn run(&mut self) {
         Terminal::initialize().unwrap();

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -17,6 +17,11 @@ pub struct Editor {
 
 impl Editor {
     pub fn new() -> Self {
+        let current_hook = std::panic::take_hook();
+        std::panic::set_hook(Box::new(move |panic_info| {
+            let _ = Terminal::terminate(); // explicitly ignore errors in terminate()
+            current_hook(panic_info);
+        }));
         let view = View::default();
         Self {
             should_quit: false,

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,12 +3,10 @@ use editor::Editor;
 
 fn main() {
     let args: Vec<_> = std::env::args().collect();
-    let mut editor;
+    let mut editor = Editor::new();
     if let Some(filename) = args.get(1) {
         // if args[1] is given, it should be filename to open
-        editor = Editor::new(filename);
-    } else {
-        editor = Editor::default();
+        editor.load_file(filename);
     }
     editor.run();
 }


### PR DESCRIPTION
closes #16 

`std::panic::set_hook` を使用してパニック時にターミナルの復元処理 (disable raw mode + leave alternate screen) を実行するようにします。
これによって、プログラムが `panic!()` で終了した場合にターミナルが復元されるためログメッセージの表示崩れなどが修正されます。

また、`default()` と `new()` で 2 箇所に `Editor` の初期化経路があると療法で hook を設定しなければならなくなって煩雑なので、初期化を `new()` のみに統一するリファクタリングを先に行いました。