### PR TITLE
refactor: refactor status bar initialization.

### DIFF
--- a/src/editor.rs
+++ b/src/editor.rs
@@ -51,16 +51,16 @@ impl Editor {
             let _ = Terminal::terminate(); // explicitly ignore errors in terminate()
             current_hook(panic_info);
         }));
+        let Size { height, .. } = Terminal::size().expect("Coud not get terminal size!");
         let status_bar_height = 1;
         let message_bar_height = 1;
         let view = Window::new(status_bar_height + message_bar_height);
-        let Size { height, .. } = Terminal::size().expect("Coud not get terminal size!");
         Self {
             should_quit: false,
             mode: EditorMode::NormalMode,
             window: view,
-            status_bar: StatusBar::new(message_bar_height),
-            command_bar: CommandBar::new(height - 1),
+            status_bar: StatusBar::new(height - status_bar_height - message_bar_height),
+            command_bar: CommandBar::new(height - message_bar_height),
             last_search_pattern: String::new(),
         }
     }

--- a/src/editor/status_bar.rs
+++ b/src/editor/status_bar.rs
@@ -5,20 +5,18 @@ use super::Terminal;
 pub struct StatusBar {
     current_status: DocumentStatus,
     needs_redraw: bool,
-    margin_bottom: usize,
     width: usize,
     position_y: usize,
 }
 
 impl StatusBar {
-    pub fn new(margin_bottom: usize) -> Self {
+    pub fn new(position_y: usize) -> Self {
         let size = Terminal::size().expect("Failed to get terminal size");
         StatusBar {
             current_status: DocumentStatus::default(),
             needs_redraw: true,
-            margin_bottom,
             width: size.width,
-            position_y: size.height - margin_bottom - 1,
+            position_y,
         }
     }
     pub fn update_status(&mut self, new_stat: DocumentStatus) {


### PR DESCRIPTION
closes #43 
Status bar の初期化方法を変更して、使われていない `margin_bottom` メンバを削除した。

まだ warning が残るが、#22, #46 で分けて対処
clippy warning の解消は、通常の warning がすべて解消されてから