### PR TITLE
Implement search highlight

### DIFF
--- a/src/editor.rs
+++ b/src/editor.rs
@@ -22,6 +22,8 @@ use command_bar::CommandBar;
 mod cmdline_commands;
 use cmdline_commands::CmdlineCommands;
 
+mod annotated_string;
+
 #[derive(Default, Eq, PartialEq, Debug)]
 pub struct DocumentStatus {
     total_lines: usize,
@@ -30,9 +32,14 @@ pub struct DocumentStatus {
     file_name: Option<String>,
 }
 
+#[derive(Debug)]
 pub enum SearchDirection {
     Forward,
     Backward,
+}
+
+pub struct RenderContext {
+    pub search_pattern: String,
 }
 
 pub struct Editor {
@@ -228,7 +235,10 @@ impl Editor {
             Terminal::clear_screen()?;
             print!("Goodbye!\r\n");
         } else {
-            self.window.render()?;
+            let context = RenderContext {
+                search_pattern: self.last_search_pattern.clone(),
+            };
+            self.window.render(&context)?;
             self.status_bar.render()?;
             self.command_bar.render()?;
             let pos = self.window.get_relative_position();

--- a/src/editor/annotated_string.rs
+++ b/src/editor/annotated_string.rs
@@ -1,0 +1,124 @@
+use crossterm::style::Color;
+use unicode_segmentation::UnicodeSegmentation;
+
+pub enum Style {
+    SearchHit,
+}
+
+pub struct DrawingOptions {
+    pub foreground_color: Color,
+    pub background_color: Color,
+}
+
+impl Style {
+    pub fn get_drawing_options(&self) -> DrawingOptions {
+        match self {
+            Self::SearchHit => DrawingOptions {
+                foreground_color: Color::White,
+                background_color: Color::Rgb {
+                    r: 104,
+                    g: 83,
+                    b: 0,
+                },
+            },
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct Annotation {
+    // byte index
+    start_idx: usize,
+    end_idx: usize,
+}
+
+pub struct Segment {
+    pub style: Option<Style>,
+    pub string: String,
+}
+
+impl Annotation {
+    pub fn new(start_idx: usize, end_idx: usize) -> Self {
+        Self { start_idx, end_idx }
+    }
+}
+
+#[derive(Default, Debug)]
+pub struct AnnotatedString {
+    string: String,
+    annots: Vec<Annotation>,
+}
+
+impl AnnotatedString {
+    pub fn from_str(s: &str) -> Self {
+        Self {
+            string: String::from(s),
+            annots: vec![],
+        }
+    }
+    pub fn add_annotation(&mut self, annot: Annotation) {
+        self.annots.push(annot);
+    }
+    pub fn get_str(&self) -> &str {
+        &self.string
+    }
+    pub fn get_annotations(&self) -> &Vec<Annotation> {
+        &self.annots
+    }
+    pub fn substr(&self, start: usize, end: usize) -> Self {
+        let sub = String::from(&self.string[start..end]);
+        let mut annots = vec![];
+        for annot in &self.annots {
+            let Annotation { start_idx, end_idx } = annot;
+            if *end_idx <= start || end <= *start_idx {
+                // annotation is out of bound
+                continue;
+            }
+            if start <= *start_idx && *end_idx <= end {
+                annots.push(annot.clone());
+            } else if *start_idx <= start && *end_idx <= end {
+                annots.push(Annotation {
+                    start_idx: start,
+                    end_idx: *end_idx,
+                });
+            } else if start <= *start_idx && end <= *end_idx {
+                annots.push(Annotation {
+                    start_idx: *start_idx,
+                    end_idx: end,
+                });
+            }
+        }
+        Self {
+            string: sub,
+            annots,
+        }
+    }
+    pub fn push_annot_str(&mut self, rhs: &AnnotatedString) {
+        let orig_len = self.string.len();
+        self.string.push_str(&rhs.string);
+        for annot in rhs.get_annotations() {
+            let Annotation { start_idx, end_idx } = annot;
+            self.add_annotation(Annotation {
+                start_idx: start_idx + orig_len,
+                end_idx: end_idx + orig_len,
+            })
+        }
+    }
+    pub fn into_segments(&self) -> Vec<Segment> {
+        let mut result = vec![];
+        for (idx, s) in self.string.grapheme_indices(true) {
+            let mut style = None;
+            for annot in &self.annots {
+                let Annotation { start_idx, end_idx } = annot;
+                if *start_idx <= idx && idx < *end_idx {
+                    style = Some(Style::SearchHit);
+                }
+            }
+            result.push(Segment {
+                style,
+                string: String::from(s),
+            })
+        }
+        result
+    }
+}

--- a/src/editor/buffer.rs
+++ b/src/editor/buffer.rs
@@ -3,7 +3,7 @@ use std::io::Write;
 use super::window::TextLocation;
 
 mod line;
-pub use line::Line;
+pub use line::{Line, LineView};
 
 pub mod grapheme;
 

--- a/src/editor/buffer/line.rs
+++ b/src/editor/buffer/line.rs
@@ -163,7 +163,10 @@ impl<'a> LineView<'a> {
         }
     }
     pub fn build_rendered_str(&self, context: &RenderContext) -> AnnotatedString {
-        let search_hits = self.line.search_all_occurence(&context.search_pattern);
+        let search_hits = match context.search_pattern.as_deref() {
+            Some(s) => self.line.search_all_occurence(s),
+            None => vec![],
+        };
         let mut content = AnnotatedString::from_str(self.line.get_raw_str());
         for (match_start, match_end) in search_hits {
             content.add_annotation(Annotation::new(match_start, match_end));

--- a/src/editor/cmdline_commands.rs
+++ b/src/editor/cmdline_commands.rs
@@ -2,6 +2,7 @@ pub enum CmdlineCommands {
     Quit,
     Write,
     Saveas(String),
+    StopHighlighting,
 }
 
 impl CmdlineCommands {
@@ -16,6 +17,8 @@ impl CmdlineCommands {
                     Err("No filename provided for `saveas` command.".to_string())
                 }
             }
+            // NO Highlight search
+            "noh" => Ok(Self::StopHighlighting),
             _ => Err(format!("No such command: {}", cmdline[0])),
         }
     }

--- a/src/editor/window.rs
+++ b/src/editor/window.rs
@@ -8,6 +8,8 @@ use super::buffer::Buffer;
 
 use super::DocumentStatus;
 
+use super::buffer::LineView;
+
 #[derive(Copy, Clone, Default)]
 pub struct TextLocation {
     pub grapheme_idx: usize,
@@ -73,7 +75,8 @@ impl Window {
             if let Some(line) = self.buffer.lines.get(i + top) {
                 let left = self.scroll_offset.col;
                 let right = left + width;
-                let display_line = line.get_visible_graphemes(left, right);
+                let view = LineView::new(&line, left, right);
+                let display_line = view.build_rendered_str();
                 self.render_line(i, &display_line)?;
             } else {
                 self.render_line(i, "~")?;

--- a/src/editor/window.rs
+++ b/src/editor/window.rs
@@ -66,6 +66,9 @@ impl Window {
             file_name: self.buffer.get_filename(),
         }
     }
+    pub fn set_needs_redraw(&mut self) {
+        self.needs_redraw = true;
+    }
     pub fn render(&mut self, context: &RenderContext) -> Result<(), std::io::Error> {
         // TODO: separate implementation of render()
         // according to whether buffer is empty or not.
@@ -101,12 +104,13 @@ impl Window {
     }
     pub fn search(
         &mut self,
-        pattern: &str,
+        pattern: Option<&str>,
         direction: SearchDirection,
     ) -> Result<(), std::io::Error> {
-        if pattern.is_empty() {
+        if pattern.is_none() {
             return Ok(());
         }
+        let pattern = pattern.unwrap();
         let result_list = self.buffer.search(pattern);
         if !result_list.is_empty() {
             match direction {


### PR DESCRIPTION
closes #48

- 検索箇所のハイライトを実装
- ハイライトの停止 (`:noh` コマンド)

実装の都合上、`get_visible_graphemes()` を廃止し、`LineView` へリファクタ