### PR TITLE
Implement syntax highlighting

### DIFF
--- a/src/editor.rs
+++ b/src/editor.rs
@@ -26,10 +26,14 @@ mod annotated_string;
 
 mod highlighter;
 
+mod filetype;
+use filetype::FileType;
+
 #[derive(Default, Eq, PartialEq, Debug)]
 pub struct DocumentStatus {
     total_lines: usize,
     current_line_index: usize,
+    file_type: FileType,
     is_modified: bool,
     file_name: Option<String>,
 }

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -46,6 +46,7 @@ pub enum SearchDirection {
 
 pub struct RenderContext {
     pub search_pattern: Option<String>,
+    pub file_type: FileType,
 }
 
 pub struct Editor {
@@ -249,8 +250,10 @@ impl Editor {
             Terminal::clear_screen()?;
             print!("Goodbye!\r\n");
         } else {
+            let status = self.window.get_status();
             let context = RenderContext {
                 search_pattern: self.last_search_pattern.clone(),
+                file_type: status.file_type,
             };
             self.window.render(&context)?;
             self.status_bar.render()?;

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -24,6 +24,8 @@ use cmdline_commands::CmdlineCommands;
 
 mod annotated_string;
 
+mod highlighter;
+
 #[derive(Default, Eq, PartialEq, Debug)]
 pub struct DocumentStatus {
     total_lines: usize,

--- a/src/editor/annotated_string.rs
+++ b/src/editor/annotated_string.rs
@@ -5,6 +5,7 @@ use unicode_segmentation::UnicodeSegmentation;
 pub enum Style {
     SearchHit,
     Digit,
+    Keywords,
 }
 
 pub struct DrawingOptions {
@@ -28,6 +29,14 @@ impl Style {
                     r: 234,
                     g: 156,
                     b: 88,
+                },
+                background_color: Color::Reset,
+            },
+            Self::Keywords => DrawingOptions {
+                foreground_color: Color::Rgb {
+                    r: 151,
+                    g: 118,
+                    b: 216,
                 },
                 background_color: Color::Reset,
             },

--- a/src/editor/annotated_string.rs
+++ b/src/editor/annotated_string.rs
@@ -6,6 +6,8 @@ pub enum Style {
     SearchHit,
     Digit,
     Keywords,
+    TypeName,
+    VarinatName,
 }
 
 pub struct DrawingOptions {
@@ -37,6 +39,22 @@ impl Style {
                     r: 151,
                     g: 118,
                     b: 216,
+                },
+                background_color: Color::Reset,
+            },
+            Self::TypeName => DrawingOptions {
+                foreground_color: Color::Rgb {
+                    r: 215,
+                    g: 189,
+                    b: 108,
+                },
+                background_color: Color::Reset,
+            },
+            Self::VarinatName => DrawingOptions {
+                foreground_color: Color::Rgb {
+                    r: 234,
+                    g: 156,
+                    b: 88,
                 },
                 background_color: Color::Reset,
             },

--- a/src/editor/annotated_string.rs
+++ b/src/editor/annotated_string.rs
@@ -8,6 +8,7 @@ pub enum Style {
     Keywords,
     TypeName,
     VarinatName,
+    Comment,
 }
 
 pub struct DrawingOptions {
@@ -55,6 +56,14 @@ impl Style {
                     r: 234,
                     g: 156,
                     b: 88,
+                },
+                background_color: Color::Reset,
+            },
+            Self::Comment => DrawingOptions {
+                foreground_color: Color::Rgb {
+                    r: 116,
+                    g: 128,
+                    b: 145,
                 },
                 background_color: Color::Reset,
             },

--- a/src/editor/annotated_string.rs
+++ b/src/editor/annotated_string.rs
@@ -5,6 +5,7 @@ use unicode_segmentation::UnicodeSegmentation;
 pub enum Style {
     SearchHit,
     Digit,
+    String,
     Keywords,
     TypeName,
     VarinatName,
@@ -32,6 +33,14 @@ impl Style {
                     r: 234,
                     g: 156,
                     b: 88,
+                },
+                background_color: Color::Reset,
+            },
+            Self::String => DrawingOptions {
+                foreground_color: Color::Rgb {
+                    r: 136,
+                    g: 178,
+                    b: 152,
                 },
                 background_color: Color::Reset,
             },

--- a/src/editor/buffer.rs
+++ b/src/editor/buffer.rs
@@ -9,6 +9,8 @@ pub use line::{Line, LineView};
 
 pub mod grapheme;
 
+use crate::editor::filetype::FileType;
+
 #[derive(Default)]
 pub struct Buffer {
     pub lines: Vec<Line>,
@@ -40,6 +42,11 @@ impl Buffer {
         self.filename = Some(filename.to_string());
         self.modified = false;
         Ok(())
+    }
+    pub fn get_filetype(&self) -> FileType {
+        self.filename
+            .as_deref()
+            .map_or(FileType::Text, |s| FileType::from_filename(s))
     }
     pub fn get_line_length(&self, line_index: usize) -> usize {
         self.lines.get(line_index).map_or(0, |line| line.len())

--- a/src/editor/buffer.rs
+++ b/src/editor/buffer.rs
@@ -2,7 +2,7 @@ use std::io::Write;
 
 use super::window::TextLocation;
 
-use super::highlighter::Highlighter;
+use super::highlighter::HighlighterBundler;
 
 mod line;
 pub use line::{Line, LineView};
@@ -112,7 +112,7 @@ impl Buffer {
         }
         result_list
     }
-    pub fn highlight(&self, highlighter: &mut Highlighter) {
+    pub fn highlight(&self, highlighter: &mut HighlighterBundler) {
         for line in self.lines.iter() {
             highlighter.highlight_line(line);
         }

--- a/src/editor/buffer.rs
+++ b/src/editor/buffer.rs
@@ -2,6 +2,8 @@ use std::io::Write;
 
 use super::window::TextLocation;
 
+use super::highlighter::Highlighter;
+
 mod line;
 pub use line::{Line, LineView};
 
@@ -102,5 +104,10 @@ impl Buffer {
             }
         }
         result_list
+    }
+    pub fn highlight(&self, highlighter: &mut Highlighter) {
+        for line in self.lines.iter() {
+            highlighter.highlight_line(line);
+        }
     }
 }

--- a/src/editor/buffer/line.rs
+++ b/src/editor/buffer/line.rs
@@ -42,6 +42,9 @@ impl Line {
     pub fn len(&self) -> usize {
         self.graphemes.len()
     }
+    pub fn byte_len(&self) -> usize {
+        self.raw_string.len()
+    }
     pub fn is_empty(&self) -> bool {
         self.len() == 0
     }

--- a/src/editor/buffer/line.rs
+++ b/src/editor/buffer/line.rs
@@ -1,3 +1,5 @@
+use unicode_segmentation::UnicodeSegmentation;
+
 use crate::editor::highlighter::LineHighlighter;
 
 use super::super::annotated_string::AnnotatedString;
@@ -110,6 +112,10 @@ impl Line {
         self.raw_string[byte_index..]
             .find(pattern)
             .map(|str_idx| byte_index + self.to_grapheme_idx(str_idx))
+    }
+
+    pub fn split_word_bound_indices(&self) -> unicode_segmentation::UWordBoundIndices<'_> {
+        self.raw_string.split_word_bound_indices()
     }
 }
 

--- a/src/editor/filetype.rs
+++ b/src/editor/filetype.rs
@@ -1,0 +1,35 @@
+use std::path::Path;
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum FileType {
+    Rust,
+    Text,
+}
+
+impl FileType {
+    pub fn from_filename(filename: &str) -> Self {
+        let ext = Path::new(filename).extension();
+        match ext {
+            Some(osstr) => osstr.to_str().map_or(Self::Text, |s| match s {
+                "rs" => Self::Rust,
+                _ => Self::Text,
+            }),
+            None => Self::Text,
+        }
+    }
+}
+
+impl Default for FileType {
+    fn default() -> Self {
+        Self::Text
+    }
+}
+
+impl std::fmt::Display for FileType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Rust => write!(f, "rust"),
+            Self::Text => write!(f, "text"),
+        }
+    }
+}

--- a/src/editor/highlighter.rs
+++ b/src/editor/highlighter.rs
@@ -7,6 +7,7 @@ use search_highlight::SearchHighlighter;
 
 struct HighlightContext {
     in_multiline_comment: bool,
+    in_string_literal: bool,
 }
 
 trait Highlighter {
@@ -35,6 +36,7 @@ impl<'a> HighlighterBundler<'a> {
             search_highlighter: SearchHighlighter::new(context),
             highlight_context: HighlightContext {
                 in_multiline_comment: false,
+                in_string_literal: false,
             },
         }
     }

--- a/src/editor/highlighter.rs
+++ b/src/editor/highlighter.rs
@@ -1,41 +1,52 @@
+mod rust;
+
 use super::{
     annotated_string::{Annotation, Style},
     buffer::Line,
     RenderContext,
 };
+use crate::editor::filetype::FileType;
 
-pub struct Highlighter<'a> {
+trait Highlighter {
+    fn highlight_line(&mut self, line: &Line);
+    fn get_annotations(&self, line_idx: usize) -> Vec<Annotation>;
+}
+
+fn create_syntax_highlighter(file_type: FileType) -> Option<Box<dyn Highlighter>> {
+    match file_type {
+        FileType::Rust => Some(Box::new(rust::RustSyntaxHighlighter::new())),
+        FileType::Text => None,
+    }
+}
+
+pub struct HighlighterBundler<'a> {
     // line index to annotations of line.
     highlights: Vec<Vec<Annotation>>,
+    syntax_highlighter: Option<Box<dyn Highlighter>>,
     render_context: &'a RenderContext,
 }
 
-impl<'a> Highlighter<'a> {
+impl<'a> HighlighterBundler<'a> {
     pub fn new(context: &'a RenderContext) -> Self {
         Self {
             highlights: Vec::new(),
+            syntax_highlighter: create_syntax_highlighter(context.file_type),
             render_context: context,
         }
     }
 
     pub fn highlight_line(&mut self, line: &Line) {
         let mut annotations = vec![];
-        Self::highlight_digits(line, &mut annotations);
+        if self.syntax_highlighter.is_some() {
+            self.syntax_highlighter
+                .as_mut()
+                .unwrap()
+                .highlight_line(line);
+        }
         self.highlight_search(line, &mut annotations);
         self.highlights.push(annotations);
     }
 
-    fn highlight_digits(line: &Line, annotations: &mut Vec<Annotation>) {
-        // digit annotations
-        line.get_raw_str()
-            .chars()
-            .enumerate()
-            .for_each(|(idx, ch)| {
-                if ch.is_ascii_digit() {
-                    annotations.push(Annotation::new(Style::Digit, idx, idx + 1));
-                }
-            });
-    }
     fn highlight_search(&self, line: &Line, annotations: &mut Vec<Annotation>) {
         // search result annotations
         let search_hits = match self.render_context.search_pattern.as_deref() {
@@ -48,17 +59,27 @@ impl<'a> Highlighter<'a> {
     }
 
     pub fn get_annotations(&self, line_idx: usize) -> Vec<Annotation> {
-        self.highlights[line_idx].clone()
+        let mut annotations = self.highlights[line_idx].clone();
+        if self.syntax_highlighter.is_some() {
+            annotations.append(
+                &mut self
+                    .syntax_highlighter
+                    .as_ref()
+                    .unwrap()
+                    .get_annotations(line_idx),
+            );
+        }
+        annotations
     }
 }
 
 pub struct LineHighlighter<'a> {
-    highlighter: &'a Highlighter<'a>,
+    highlighter: &'a HighlighterBundler<'a>,
     line_idx: usize,
 }
 
 impl<'a> LineHighlighter<'a> {
-    pub fn new(highlighter: &'a Highlighter, line_idx: usize) -> Self {
+    pub fn new(highlighter: &'a HighlighterBundler, line_idx: usize) -> Self {
         Self {
             highlighter,
             line_idx,

--- a/src/editor/highlighter.rs
+++ b/src/editor/highlighter.rs
@@ -1,0 +1,70 @@
+use super::{
+    annotated_string::{Annotation, Style},
+    buffer::Line,
+    RenderContext,
+};
+
+pub struct Highlighter<'a> {
+    // line index to annotations of line.
+    highlights: Vec<Vec<Annotation>>,
+    render_context: &'a RenderContext,
+}
+
+impl<'a> Highlighter<'a> {
+    pub fn new(context: &'a RenderContext) -> Self {
+        Self {
+            highlights: Vec::new(),
+            render_context: context,
+        }
+    }
+
+    pub fn highlight_line(&mut self, line: &Line) {
+        let mut annotations = vec![];
+        Self::highlight_digits(line, &mut annotations);
+        self.highlight_search(line, &mut annotations);
+        self.highlights.push(annotations);
+    }
+
+    fn highlight_digits(line: &Line, annotations: &mut Vec<Annotation>) {
+        // digit annotations
+        line.get_raw_str()
+            .chars()
+            .enumerate()
+            .for_each(|(idx, ch)| {
+                if ch.is_ascii_digit() {
+                    annotations.push(Annotation::new(Style::Digit, idx, idx + 1));
+                }
+            });
+    }
+    fn highlight_search(&self, line: &Line, annotations: &mut Vec<Annotation>) {
+        // search result annotations
+        let search_hits = match self.render_context.search_pattern.as_deref() {
+            Some(s) => line.search_all_occurence(s),
+            None => vec![],
+        };
+        for (match_start, match_end) in search_hits {
+            annotations.push(Annotation::new(Style::SearchHit, match_start, match_end));
+        }
+    }
+
+    pub fn get_annotations(&self, line_idx: usize) -> Vec<Annotation> {
+        self.highlights[line_idx].clone()
+    }
+}
+
+pub struct LineHighlighter<'a> {
+    highlighter: &'a Highlighter<'a>,
+    line_idx: usize,
+}
+
+impl<'a> LineHighlighter<'a> {
+    pub fn new(highlighter: &'a Highlighter, line_idx: usize) -> Self {
+        Self {
+            highlighter,
+            line_idx,
+        }
+    }
+    pub fn get_annotations(&self) -> Vec<Annotation> {
+        self.highlighter.get_annotations(self.line_idx)
+    }
+}

--- a/src/editor/highlighter/rust.rs
+++ b/src/editor/highlighter/rust.rs
@@ -2,6 +2,10 @@ use super::Highlighter;
 use crate::editor::annotated_string::{Annotation, Style};
 use crate::editor::buffer::Line;
 
+const KEYWORDS: [&str; 12] = [
+    "fn", "mod", "use", "pub", "if", "else", "for", "in", "struct", "impl", "let", "match",
+];
+
 pub struct RustSyntaxHighlighter {
     highlights: Vec<Vec<Annotation>>,
 }
@@ -12,23 +16,29 @@ impl RustSyntaxHighlighter {
             highlights: Vec::new(),
         }
     }
-    fn highlight_digits(line: &Line, annotations: &mut Vec<Annotation>) {
-        // digit annotations
-        line.get_raw_str()
-            .chars()
-            .enumerate()
-            .for_each(|(idx, ch)| {
-                if ch.is_ascii_digit() {
-                    annotations.push(Annotation::new(Style::Digit, idx, idx + 1));
-                }
-            });
-    }
+}
+
+fn is_number(word: &str) -> bool {
+    word.chars().all(|char| char.is_ascii_digit())
+}
+
+fn is_keyword(word: &str) -> bool {
+    KEYWORDS.contains(&word)
 }
 
 impl Highlighter for RustSyntaxHighlighter {
     fn highlight_line(&mut self, line: &Line) {
         let mut annotations = vec![];
-        Self::highlight_digits(line, &mut annotations);
+        for (idx, word) in line.split_word_bound_indices() {
+            let annotation = if is_number(word) {
+                Some(Annotation::new(Style::Digit, idx, idx + word.len()))
+            } else if is_keyword(word) {
+                Some(Annotation::new(Style::Keywords, idx, idx + word.len()))
+            } else {
+                None
+            };
+            annotation.map_or((), |annot| annotations.push(annot))
+        }
         self.highlights.push(annotations);
     }
     fn get_annotations(&self, line_idx: usize) -> Vec<Annotation> {

--- a/src/editor/highlighter/rust.rs
+++ b/src/editor/highlighter/rust.rs
@@ -6,6 +6,21 @@ const KEYWORDS: [&str; 12] = [
     "fn", "mod", "use", "pub", "if", "else", "for", "in", "struct", "impl", "let", "match",
 ];
 
+const TYPE_NAMES: [&str; 21] = [
+    "i8", "i16", "i32", "i64", "i128", "isize", // signed integeres
+    "u8", "u16", "u32", "u64", "u128", "usize", // unsigned integeres
+    "f32", "f64", // floating point numbers
+    "bool", "char", "str", // other builtin types
+    "Option", "Result", // enum types in std::prelude
+    "String", "Vec", // struct types in std::prelude
+];
+
+const VARIANT_NAMES: [&str; 6] = [
+    "true", "false", // bool
+    "Some", "None", // Option
+    "Ok", "Err", // Result
+];
+
 pub struct RustSyntaxHighlighter {
     highlights: Vec<Vec<Annotation>>,
 }
@@ -26,6 +41,14 @@ fn is_keyword(word: &str) -> bool {
     KEYWORDS.contains(&word)
 }
 
+fn is_type_name(word: &str) -> bool {
+    TYPE_NAMES.contains(&word)
+}
+
+fn is_variant_name(word: &str) -> bool {
+    VARIANT_NAMES.contains(&word)
+}
+
 impl Highlighter for RustSyntaxHighlighter {
     fn highlight_line(&mut self, line: &Line) {
         let mut annotations = vec![];
@@ -34,6 +57,10 @@ impl Highlighter for RustSyntaxHighlighter {
                 Some(Annotation::new(Style::Digit, idx, idx + word.len()))
             } else if is_keyword(word) {
                 Some(Annotation::new(Style::Keywords, idx, idx + word.len()))
+            } else if is_type_name(word) {
+                Some(Annotation::new(Style::TypeName, idx, idx + word.len()))
+            } else if is_variant_name(word) {
+                Some(Annotation::new(Style::VarinatName, idx, idx + word.len()))
             } else {
                 None
             };

--- a/src/editor/highlighter/rust.rs
+++ b/src/editor/highlighter/rust.rs
@@ -1,0 +1,37 @@
+use super::Highlighter;
+use crate::editor::annotated_string::{Annotation, Style};
+use crate::editor::buffer::Line;
+
+pub struct RustSyntaxHighlighter {
+    highlights: Vec<Vec<Annotation>>,
+}
+
+impl RustSyntaxHighlighter {
+    pub fn new() -> Self {
+        Self {
+            highlights: Vec::new(),
+        }
+    }
+    fn highlight_digits(line: &Line, annotations: &mut Vec<Annotation>) {
+        // digit annotations
+        line.get_raw_str()
+            .chars()
+            .enumerate()
+            .for_each(|(idx, ch)| {
+                if ch.is_ascii_digit() {
+                    annotations.push(Annotation::new(Style::Digit, idx, idx + 1));
+                }
+            });
+    }
+}
+
+impl Highlighter for RustSyntaxHighlighter {
+    fn highlight_line(&mut self, line: &Line) {
+        let mut annotations = vec![];
+        Self::highlight_digits(line, &mut annotations);
+        self.highlights.push(annotations);
+    }
+    fn get_annotations(&self, line_idx: usize) -> Vec<Annotation> {
+        self.highlights[line_idx].clone()
+    }
+}

--- a/src/editor/highlighter/search_highlight.rs
+++ b/src/editor/highlighter/search_highlight.rs
@@ -1,0 +1,39 @@
+use super::Highlighter;
+use crate::editor::annotated_string::{Annotation, Style};
+use crate::editor::buffer::Line;
+use crate::editor::RenderContext;
+
+pub struct SearchHighlighter<'a> {
+    highlights: Vec<Vec<Annotation>>,
+    render_context: &'a RenderContext,
+}
+
+impl<'a> SearchHighlighter<'a> {
+    pub fn new(render_context: &'a RenderContext) -> Self {
+        Self {
+            highlights: Vec::new(),
+            render_context,
+        }
+    }
+    fn highlight_search(&self, line: &Line, annotations: &mut Vec<Annotation>) {
+        // search result annotations
+        let search_hits = match self.render_context.search_pattern.as_deref() {
+            Some(s) => line.search_all_occurence(s),
+            None => vec![],
+        };
+        for (match_start, match_end) in search_hits {
+            annotations.push(Annotation::new(Style::SearchHit, match_start, match_end));
+        }
+    }
+}
+
+impl<'a> Highlighter for SearchHighlighter<'a> {
+    fn highlight_line(&mut self, line: &Line) {
+        let mut annotations = vec![];
+        self.highlight_search(line, &mut annotations);
+        self.highlights.push(annotations);
+    }
+    fn get_annotations(&self, line_idx: usize) -> Vec<Annotation> {
+        self.highlights[line_idx].clone()
+    }
+}

--- a/src/editor/highlighter/search_highlight.rs
+++ b/src/editor/highlighter/search_highlight.rs
@@ -1,4 +1,4 @@
-use super::Highlighter;
+use super::{HighlightContext, Highlighter};
 use crate::editor::annotated_string::{Annotation, Style};
 use crate::editor::buffer::Line;
 use crate::editor::RenderContext;
@@ -28,7 +28,7 @@ impl<'a> SearchHighlighter<'a> {
 }
 
 impl<'a> Highlighter for SearchHighlighter<'a> {
-    fn highlight_line(&mut self, line: &Line) {
+    fn highlight_line(&mut self, line: &Line, _ctx: &mut HighlightContext) {
         let mut annotations = vec![];
         self.highlight_search(line, &mut annotations);
         self.highlights.push(annotations);

--- a/src/editor/status_bar.rs
+++ b/src/editor/status_bar.rs
@@ -41,7 +41,8 @@ impl StatusBar {
         };
         let left_status = format!("{} {}", buffer_name, modified_status_str);
         let right_status = format!(
-            "{}/{}",
+            "[{}] {}/{}",
+            self.current_status.file_type.to_string(),
             self.current_status.current_line_index + 1, // 0-idx to 1-idx
             usize::max(1, self.current_status.total_lines), // If the buffer is empty, it is treated as a single line.
         );

--- a/src/editor/window.rs
+++ b/src/editor/window.rs
@@ -13,6 +13,8 @@ use super::DocumentStatus;
 
 use super::buffer::LineView;
 
+use super::highlighter::{Highlighter, LineHighlighter};
+
 #[derive(Copy, Clone, Default, Debug)]
 pub struct TextLocation {
     pub grapheme_idx: usize,
@@ -75,6 +77,8 @@ impl Window {
         if !self.needs_redraw {
             return Ok(());
         }
+        let mut highlighter = Highlighter::new(context);
+        self.buffer.highlight(&mut highlighter);
         let top = self.scroll_offset.row;
         let Size { height, width } = self.size;
         for i in 0..height {
@@ -82,7 +86,8 @@ impl Window {
                 let left = self.scroll_offset.col;
                 let right = left + width;
                 let view = LineView::new(&line, left, right);
-                let display_line = view.build_rendered_str(context);
+                let line_highlighter = LineHighlighter::new(&highlighter, i + top);
+                let display_line = view.build_rendered_str(&line_highlighter);
                 self.render_line(i, &display_line)?;
             } else {
                 self.render_line(i, &AnnotatedString::from_str("~"))?;

--- a/src/editor/window.rs
+++ b/src/editor/window.rs
@@ -64,6 +64,7 @@ impl Window {
         DocumentStatus {
             total_lines: self.buffer.get_n_lines(),
             current_line_index: self.cursor_location.line_idx,
+            file_type: self.buffer.get_filetype(),
             is_modified: self.buffer.modified,
             file_name: self.buffer.get_filename(),
         }

--- a/src/editor/window.rs
+++ b/src/editor/window.rs
@@ -13,7 +13,7 @@ use super::DocumentStatus;
 
 use super::buffer::LineView;
 
-use super::highlighter::{Highlighter, LineHighlighter};
+use super::highlighter::{HighlighterBundler, LineHighlighter};
 
 #[derive(Copy, Clone, Default, Debug)]
 pub struct TextLocation {
@@ -78,7 +78,7 @@ impl Window {
         if !self.needs_redraw {
             return Ok(());
         }
-        let mut highlighter = Highlighter::new(context);
+        let mut highlighter = HighlighterBundler::new(context);
         self.buffer.highlight(&mut highlighter);
         let top = self.scroll_offset.row;
         let Size { height, width } = self.size;


### PR DESCRIPTION
closes #54 

以下の項目のハイライトを実装

- Keyword
- Type name, Variant name
- 10進リテラル
- 文字列リテラル (`" ... "`) (ダブルクオートのエスケープ (`\"`) は非対応)
- コメント
  - Single line (`//`)
  - Multi line (`/* ... */`) (ネストは非対応)