### PR TITLE
fix: fix search for single character at line end

### DIFF
--- a/src/editor/buffer.rs
+++ b/src/editor/buffer.rs
@@ -92,14 +92,16 @@ impl Buffer {
         // return first match in the entire buffer
         let mut result_list = vec![];
         for (line_idx, line) in self.lines.iter().enumerate() {
-            let mut start_index = 0;
-            while let Some(grapheme_idx) = line.search(pattern, start_index) {
-                result_list.push(TextLocation {
-                    grapheme_idx,
-                    line_idx,
-                });
-                start_index = grapheme_idx + 1;
-            }
+            let search_hits = line.search_all_occurence(pattern);
+            result_list.append(
+                &mut search_hits
+                    .iter()
+                    .map(|(str_idx, _)| TextLocation {
+                        line_idx,
+                        grapheme_idx: line.to_grapheme_idx(*str_idx),
+                    })
+                    .collect::<Vec<_>>(),
+            );
         }
         result_list
     }

--- a/src/editor/buffer/line.rs
+++ b/src/editor/buffer/line.rs
@@ -93,14 +93,15 @@ impl Line {
             return result;
         }
         let mut start_index = 0;
-        while let Some(grapheme_idx) = self.search(pattern, start_index) {
-            let start = grapheme_idx;
+        while let Some(start) = self.search(pattern, start_index) {
             let end = start + pattern.len();
             result.push((start, end));
-            start_index = grapheme_idx + 1;
+            start_index = self.to_grapheme_idx(start) + 1;
         }
         result
     }
+    // search pattern in a line after start_idx (in graphemes) and
+    // returns first index in bytes.
     pub fn search(&self, pattern: &str, start_idx: usize) -> Option<usize> {
         if self.is_empty() {
             return None;
@@ -108,7 +109,7 @@ impl Line {
         let byte_index = self.to_str_idx[start_idx];
         self.raw_string[byte_index..]
             .find(pattern)
-            .map(|str_idx| byte_index + self.to_grapheme_idx(str_idx))
+            .map(|str_idx| byte_index + str_idx)
     }
 }
 

--- a/src/editor/buffer/line.rs
+++ b/src/editor/buffer/line.rs
@@ -99,6 +99,9 @@ impl Line {
             let end = start + pattern.len();
             result.push((start, end));
             start_index = self.to_grapheme_idx(start) + 1;
+            if start_index >= self.len() {
+                break;
+            }
         }
         result
     }

--- a/src/editor/buffer/line.rs
+++ b/src/editor/buffer/line.rs
@@ -79,7 +79,7 @@ impl Line {
             .cloned()
             .unwrap_or(self.raw_string.len())
     }
-    fn to_grapheme_idx(&self, str_idx: usize) -> usize {
+    pub fn to_grapheme_idx(&self, str_idx: usize) -> usize {
         for (grapheme_idx, cur_str_idx) in self.to_str_idx.iter().enumerate() {
             if *cur_str_idx >= str_idx {
                 return grapheme_idx;
@@ -88,6 +88,8 @@ impl Line {
         panic!("Error: str index is out of bound");
     }
     pub fn search_all_occurence(&self, pattern: &str) -> Vec<(usize, usize)> {
+        // Returns: vector of (start, end)
+        // start, end indices are in byte indices
         let mut result = vec![];
         if pattern.is_empty() {
             return result;
@@ -102,7 +104,7 @@ impl Line {
     }
     // search pattern in a line after start_idx (in graphemes) and
     // returns first index in bytes.
-    pub fn search(&self, pattern: &str, start_idx: usize) -> Option<usize> {
+    fn search(&self, pattern: &str, start_idx: usize) -> Option<usize> {
         if self.is_empty() {
             return None;
         }


### PR DESCRIPTION
fix #58 

直接的な out of bound error の修正は 7cfcaf96d90927679dd9ff4f18d22a8aff73afd6 になります。

`Buffer::search()` が `Line::search_all_occurences()` を使用するようになっていないと修正の効果が無いため、先に 2ce9ada18554958ad4ce4021143dd710b97a7aab にて `Line::search_all_occurences()` による実装を用いるようにリファクタを行っています。
さらに、search の index の取り扱いに明らかな不整合があり、目的の修正を行う上で考慮する必要があったため 450e5479d7e5b6b662ac71b12579701085b84fa5 にて index の扱いが整合するよう変更しています。