### PR TITLE
fix: fix misplaced highlight range when scrolling

### DIFF
--- a/src/editor/annotated_string.rs
+++ b/src/editor/annotated_string.rs
@@ -75,16 +75,21 @@ impl AnnotatedString {
                 continue;
             }
             if start <= *start_idx && *end_idx <= end {
-                annots.push(annot.clone());
+                // Shift annotation position
+                let substrt_annot = Annotation {
+                    start_idx: start_idx - start,
+                    end_idx: end_idx - start,
+                };
+                annots.push(substrt_annot);
             } else if *start_idx <= start && *end_idx <= end {
                 annots.push(Annotation {
-                    start_idx: start,
-                    end_idx: *end_idx,
+                    start_idx: 0,
+                    end_idx: *end_idx - start,
                 });
             } else if start <= *start_idx && end <= *end_idx {
                 annots.push(Annotation {
-                    start_idx: *start_idx,
-                    end_idx: end,
+                    start_idx: *start_idx - start,
+                    end_idx: end - start,
                 });
             }
         }


### PR DESCRIPTION
fix #60 

Fixed the highlight misplacement when we scroll window.
When we take substring of AnnotatedString, highlight range of original string should be adjusted to new substring's byte index.