### PR TITLE
fix: prevent old search highlight from remaining

### DIFF
--- a/src/editor/window.rs
+++ b/src/editor/window.rs
@@ -107,6 +107,8 @@ impl Window {
         pattern: Option<&str>,
         direction: SearchDirection,
     ) -> Result<(), std::io::Error> {
+        // Always redraw to update search highlight
+        self.needs_redraw = true;
         if pattern.is_none() {
             return Ok(());
         }
@@ -139,7 +141,6 @@ impl Window {
                     }
                 }
             }
-            self.needs_redraw = true;
             Ok(())
         } else {
             Terminal::print_log(&format!("Pattern not found: {}", pattern))?;


### PR DESCRIPTION
fix #61 

Always redraw after executing search command to ensure the search highlights are updated.